### PR TITLE
Add files to create RPMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 inlets
 inlets-linux
 inlets-darwin
+inlets-*.rpm

--- a/hack/createRPM.sh
+++ b/hack/createRPM.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Based on https://github.com/cernbox/ocmd/blob/master/Makefile
+
+set -xe
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SPECFILE="${SCRIPTDIR}/inlets.spec"
+PACKAGE=$(awk '$1 == "Name:"     { print $2 }' ${SPECFILE})
+VERSION=$(awk '$1 == "Version:"  { print $2 }' ${SPECFILE})
+RELEASE=$(awk '$1 == "Release:"  { print $2 }' ${SPECFILE})
+
+rpmbuild=$(mktemp -d)
+
+mkdir -p ${rpmbuild}/{RPMS,SPECS,SOURCES,BUILD,SRPMS}
+mkdir -p ${rpmbuild}/RPMS/x86_64/
+
+dep ensure
+go build
+
+TEMPDIR=$(mktemp -d)
+mkdir -p ${TEMPDIR}/${PACKAGE}-${VERSION}
+
+cp -r hack/inlets.service inlets LICENSE README.md ${TEMPDIR}/${PACKAGE}-${VERSION}/
+tar cpfz ${rpmbuild}/SOURCES/${PACKAGE}-${VERSION}.tar.gz --directory=${TEMPDIR} ${PACKAGE}-${VERSION}
+
+cp ${SPECFILE} ${rpmbuild}/SPECS/
+
+rpmbuild --define="_topdir ${rpmbuild}" \
+        --define="_sourcedir %{_topdir}/SOURCES" \
+        --define="_builddir %{_topdir}/BUILD" \
+        --define="_srcrpmdir %{_topdir}/SRPMS" \
+        --define="_rpmdir %{_topdir}/RPMS" \
+        --nodeps -bb ${rpmbuild}/SPECS/${PACKAGE}.spec
+
+cp ${rpmbuild}/RPMS/x86_64/* .
+
+rm -Rf ${rpmbuild} ${TEMPDIR}

--- a/hack/inlets.spec
+++ b/hack/inlets.spec
@@ -1,0 +1,47 @@
+# Based on https://github.com/cernbox/ocmd/blob/master/ocmd.spec
+%global debug_package %{nil}
+
+Name:           inlets
+Release:        1%{?dist}
+Summary:        Expose your local endpoints to the Internet
+Version:        2.6.1
+License:        MIT
+URL:            https://github.com/inlets/inlets
+Source0:        https://github.com/inlets/inlets/archive/%{name}-%{version}.tar.gz
+
+BuildRequires: systemd
+BuildRequires: systemd-rpm-macros
+
+%description
+Expose your local endpoints to the Internet
+
+%prep
+%setup -n %{name}-%{version}
+
+%build
+
+%install
+install -d %{buildroot}/usr/local/bin
+install -d %{buildroot}/etc/default
+install -d %{buildroot}%{_unitdir}
+install -p -m 0755 inlets %{buildroot}/usr/local/bin/inlets
+install -p -m 644 inlets.service %{buildroot}%{_unitdir}
+
+%files
+%license LICENSE
+%doc README.md
+/usr/local/bin/inlets
+%{_unitdir}/*
+
+%post
+%systemd_post inlets.service
+
+%preun
+%systemd_preun inlets.service
+
+%postun
+%systemd_postun inlets.service
+
+%changelog
+* Mon Oct 21 2019 Eduardo Minguez Perez <e.minguez@gmail.com> - 2.6.1-1
+- Initial package


### PR DESCRIPTION
Signed-off-by: Eduardo Minguez Perez <e.minguez@gmail.com>

## Description
Added a script and a spec file to be able to build an RPM

I've been trying to do a better spec based on the [official documentation](https://docs.fedoraproject.org/en-US/packaging-guidelines/Golang/) but it seems that it only works in Fedora 31 (unreleased yet). Also due to the project uses dep I'm not sure if doing it properly [will work](https://fedoraproject.org/wiki/More_Go_packaging#Limitations)

## How Has This Been Tested?
Fedora 30 box:

```
sudo dnf install rpm-build redhat-rpm-config
sh -x hack/createRPM.sh
sudo dnf install ./inlets-*.rpm -y
```

Check:
```
$ rpm -ql inlets
/usr/lib/systemd/system/inlets.service
/usr/local/bin/inlets
/usr/share/doc/inlets
/usr/share/doc/inlets/README.md
/usr/share/licenses/inlets
/usr/share/licenses/inlets/LICENSE
$ systemctl status inlets
● inlets.service - Inlets Server Service
   Loaded: loaded (/usr/lib/systemd/system/inlets.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
```
## How are existing users impacted? What migration steps/scripts do we need?
No impact, just a new artifact will be available (RPM)

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
