### PR TITLE
Updating Ubuntu base image on Scaleway provision

### DIFF
--- a/hack/provision-scaleway.sh
+++ b/hack/provision-scaleway.sh
@@ -8,7 +8,7 @@ echo "Creating: $NAME"
 
 rm ~/.scw-cache.db
 
-scw --region=$REGION run --detach -u="cloud-init=@$USERDATA" --commercial-type=START1-XS --name=$NAME ubuntu-mini-xenial-25g
+scw --region=$REGION run --detach -u="cloud-init=@$USERDATA" --commercial-type=START1-XS --name=$NAME Ubuntu_Bionic
 
 for i in {0..100};
 do
@@ -28,6 +28,3 @@ do
     break
   fi
 done
-
-
-


### PR DESCRIPTION
Signed-off-by: Flavio Meyer <flavio.meyer@flavio-meyer.ch>

## Description
Updating Ubuntu base image on Scaleway provision because it's currently not working [#118].

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mac OSX 10.15.
`./hack/provision-scaleway.sh`

<img width="548" alt="Scaleway_console_output" src="https://user-images.githubusercontent.com/28959963/67161996-431e9b00-f360-11e9-97a2-f9cb7ed9b3a8.png">


## How are existing users impacted? What migration steps/scripts do we need?
Existing users aren't impacted. This fix is only for new inlets instances on Scaleway with auto provision bash script `./hack/provision-scaleway.sh`.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
