### PR TITLE
Switch to writable test in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -4,6 +4,7 @@
 export OWNER=inlets
 export REPO=inlets
 export SUCCESS_CMD="$REPO version"
+export BINLOCATION="/usr/local/bin"
 
 version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 
@@ -13,7 +14,7 @@ if [ ! $version ]; then
     echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"
     echo "2. Download the latest release for your platform. Call it '$REPO'."
     echo "3. chmod +x ./$REPO"
-    echo "4. mv ./$REPO /usr/local/bin"
+    echo "4. mv ./$REPO $BINLOCATION"
     exit 1
 fi
 
@@ -83,26 +84,27 @@ getPackage() {
 
     echo "Download complete."
 
-        if [ "$userid" != "0" ]; then
+        if [ ! -w "$BINLOCATION" ]; then
 
             echo
-            echo "========================================================="
-            echo "==    As the script was run as a non-root user the     =="
-            echo "==    following commands may need to be run manually   =="
-            echo "========================================================="
+            echo "============================================================"
+            echo "==   The script was run as a user who is unable to write  =="
+            echo "==   to $BINLOCATION. To complete the installation the  =="
+            echo "==   following commands may need to be run manually.      =="
+            echo "============================================================"
             echo
-            echo "  sudo cp $REPO$suffix /usr/local/bin/$REPO"
+            echo "  sudo cp $REPO$suffix $BINLOCATION/$REPO"
             echo
             ./$REPO$suffix version
         else
 
             echo
-            echo "Running as root - Attempting to move $REPO to /usr/local/bin"
+            echo "Running with sufficient permissions to attempt to move $REPO to $BINLOCATION"
 
-            mv $targetFile /usr/local/bin/$REPO
+            mv $targetFile $BINLOCATION/$REPO
 
             if [ "$?" = "0" ]; then
-                echo "New version of $REPO installed to /usr/local/bin"
+                echo "New version of $REPO installed to $BINLOCATION"
             fi
 
             if [ -e $targetFile ]; then


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
The evaluation prior to moving the binary in get.sh was checking for the root user.  However, if the current user has sufficient privileges to write to the target location then there would be no reason not to attempt the move as the current user.

This change moves the if statement away from testing for the root user and instead checks for writability for the current location.

## How Has This Been Tested?
### As a user with write access:

```sh
$ ls -ld /usr/local/bin
drwxrwxr-x  325 rgee0  staff  10400 22 Oct 20:10 /usr/local/bin
$ id -F
RGee0
$ ./get.sh

You already have the inlets cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/inlets/inlets/releases/download/2.6.1/inlets-darwin as /Users/rgee0/go/src/github.com/alexellis/inlets/inlets-darwin
Download complete.

Running with sufficient permissions to attempt to move inlets to /usr/local/bin
New version of inlets installed to /usr/local/bin
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.1
Git Commit: 5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae
```
### Using sudo:

```sh
$ sudo ./get.sh
Password:

You already have the inlets cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/inlets/inlets/releases/download/2.6.1/inlets-darwin as /tmp/inlets-darwin
Download complete.

Running with sufficient permissions to attempt to move inlets to /usr/local/bin
New version of inlets installed to /usr/local/bin
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.1
Git Commit: 5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae
```

### As a guest user:
```sh
$ ls -ld /usr/local/bin
drwxrwxr-x  325 rgee0  staff  10400 22 Oct 20:30 /usr/local/bin
$ id -F
Guest User
$ ./get.sh

You already have the inlets cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/inlets/inlets/releases/download/2.6.1/inlets-darwin as /tmp/inlets-darwin
Download complete.

============================================================
==   The script was run as a user who is unable to write  ==
==   to /usr/local/bin. To complete the installation the  ==
==   following commands may need to be run manually.      ==
============================================================

  sudo cp inlets-darwin /usr/local/bin/inlets

 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.1
Git Commit: 5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae
```

## How are existing users impacted? What migration steps/scripts do we need?
Not impacting

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
