### PR TITLE
Remove notice about canceling download of script

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -20,17 +20,6 @@ fi
 
 hasCli() {
 
-    has=$(which $REPO)
-
-    if [ "$?" = "0" ]; then
-        echo
-        echo "You already have the $REPO cli!"
-        export n=1
-        echo "Overwriting in $n seconds.. Press Control+C to cancel."
-        echo
-        sleep $n
-    fi
-
     hasCurl=$(which curl)
     if [ "$?" = "1" ]; then
         echo "You need curl to use this script."


### PR DESCRIPTION
There was a notice to cancel download of the script if you had
it installed that was set to say you had 1 second to cancel.
We always install the latest version so if a user wants to
reinstall then its fine. The check has been removed.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
There was a 1 second delay to cancel if a user already had the binary installed - It now just installs latest release onto their machine without the cancel in 1 second message

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
