### PR TITLE
Fix Service example to use correct selector

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: inlets
   labels:
-    app: inlets
+    app.kubernetes.io/name: inlets
 spec:
   type: ClusterIP
   ports:
@@ -133,7 +133,7 @@ spec:
       protocol: TCP
       targetPort: 8000
   selector:
-    app: inlets
+    app.kubernetes.io/name: inlets
 ```
 
 * Create a `Deployment`:


### PR DESCRIPTION
## Description
The example Service in the Kubernetes documentaion uses the wrong selector.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## How are existing users impacted? What migration steps/scripts do we need?
N/A

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] ~added unit tests~ N/A
