### PR TITLE
Simplifies Code Contributions by adding gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks: 
+  - init: go get -u github.com/inlets/inlets
+    command: cd $GOPATH/src/github.com/inlets/inlets

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Expose your local endpoints to the Internet
 
 [![Build Status](https://travis-ci.org/inlets/inlets.svg?branch=master)](https://travis-ci.org/inlets/inlets) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Go Report Card](https://goreportcard.com/badge/github.com/inlets/inlets)](https://goreportcard.com/report/github.com/inlets/inlets) [![Documentation](https://godoc.org/github.com/inlets/inlets?status.svg)](http://godoc.org/github.com/inlets/inlets) [![Derek App](https://alexellis.o6s.io/badge?owner=inlets&repo=inlets)](https://github.com/alexellis/derek/)
+[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 ## Intro
 
@@ -318,5 +319,9 @@ You can get the code like this:
 go get -u github.com/inlets/inlets
 cd $GOPATH/src/github.com/inlets/inlets
 ```
+
+Alternatively, you can get everything setup right in the browser with a single click using [Gitpod](https://gitpod.io):
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/inlets/inlets)
 
 Contributions are welcome. All commits must be signed-off with `git commit -s` to accept the [Developer Certificate of Origin](https://developercertificate.org).


### PR DESCRIPTION
Signed-off-by: Nisar Hassan Naqvi <syednisarhassan12@gmail.com>

## Description

Hi! :slightly_smiling_face: 

This PR adds information and a little bit of config to simplify onboarding using Gitpod so that we can list the project on https://contribute.dev as asked by @alexellis 

![image](https://user-images.githubusercontent.com/46004116/68735820-a965a900-0600-11ea-8f2b-6490027d48d5.png)


You can try it out on my Fork of the Repo:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nisarhassan12/inlets)

It seems to work well!

![image](https://user-images.githubusercontent.com/46004116/68735956-298c0e80-0601-11ea-88e8-00b78cee2405.png)

After the merge of this PR the project will soon be listed on https://contribute.dev

fixes gitpod-io/contribute.dev#33

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
