### PR TITLE
[gitpod] Improve .gitpod.yml for a better Go setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,20 @@
+checkoutLocation: go/src/github.com/inlets/inlets
+workspaceLocation: go/src/github.com/inlets/inlets
+ports:
+  - port: 8090
+    onOpen: ignore
 tasks: 
-  - init: go get -u github.com/inlets/inlets
-    command: cd $GOPATH/src/github.com/inlets/inlets
+  - init: go get -v ./...
+    command: |
+      head -c 16 /dev/urandom | shasum | cut -d" " -f1 > /tmp/inlets-token
+      inlets server --port=8090 --token="$(cat /tmp/inlets-token)"
+  - command: |
+      clear
+      gp await-port 8090 &&
+      remote=$(gp url 8090)
+      echo
+      echo "Inlets server is running on $(gp url 8090)."
+      echo "$(tput setaf 7)You can tunnel to it using $(tput setaf 2)inlets client --remote=${remote/https/wss} --token $(cat /tmp/inlets-token) --upstream=http://127.0.0.1:3000$(tput sgr0)"
+      echo
+      echo "Once you have an inlet client connected, head over to $(tput setaf 4)$(gp url 8090)$(tput sgr0) to access that service."
+    openMode: split-right


### PR DESCRIPTION
## Description

This PR improves the setup of Gitpod workspaces for `inlet`. Upon workspace startup it runs `go get`, starts the inlet server and offers instructions how to connect to it. This way users can directly try inlets with an endpoint exposed to the internet.

<img width="3008" alt="Screenshot 2019-11-13 at 11 16 28" src="https://user-images.githubusercontent.com/3210701/68754614-50e5da00-0607-11ea-98a7-9c1a280ba2ce.png">

## How Has This Been Tested?
I have opened a Gitpod workspace on my fork. To test these changes open this workspace: https://gitpod.io/#https://github.com/32leaves/inlets


## How are existing users impacted? What migration steps/scripts do we need?
Existing and new users have an easier time developing, and trying inlets.
No migration required.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [X] added unit tests
