### PR TITLE
Pass Host header to allow its use in --upstream

### DIFF
--- a/contrib/nginx.md
+++ b/contrib/nginx.md
@@ -15,6 +15,7 @@ server {
         proxy_http_version 1.1;
         proxy_read_timeout 120s;
         proxy_connect_timeout 120s;
+        proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }


### PR DESCRIPTION
## Description

When using original configuration proposed here,  I couldn't figure out why why something like  `inlets client --remote wss://inlet.example.com --upstream="foo.example.com=http://127.0.0.1:8000"` --token=my_token wouldn't work. If I removed the host= and set `--upstream="http://127.0.0.1:8000"` everything was fine, and that is when I realized I needed to the send the host header along. Once this was added, the `--upstream="foo.example.com=http://127.0.0.1:8000"` would work.


## How Has This Been Tested?
updated config / restarted Nginx (nginx version: nginx/1.14.0 (Ubuntu)) running on Linode
restarted client and include host= in upstream and verified that curl works.

## How are existing users impacted? What migration steps/scripts do we need?

N/A  as this just a documentation update

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X ] signed-off my commits with `git commit -s`
- [ N/A] added unit tests
