### PR TITLE
Running `hash-browns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,9 @@ You can use my hash-browns service for instance which generates hashes.
 Install hash-browns or run your own HTTP server
 
 ```sh
-export GO111MODULE=off
-export GOPATH=$HOME/go/
-
 go get -u github.com/alexellis/hash-browns
-cd $GOPATH/src/github.com/alexellis/hash-browns
 
-port=3000 go run server.go
+port=3000 ${GOPATH}/bin/hash-browns
 ```
 
 If you don't have Go installed, then you could run [Python's built-in HTTP server](https://docs.python.org/2/library/simplehttpserver.html):


### PR DESCRIPTION
The instructions are incorrect, there's no `server.go`.

IIUC `go get -u` will build a binary in `${GOPATH}/bin` anyway and, if this is PATHed, the user could just:

```bash
go get -u github.com/alexellis/hash-browns

port=3000 hash-browns
```
Or:

+ `port=3000 ${GOPATH}/bin/hash-browns`
+ `port=3000 go run github.com/alexellis/hash-browns`
+ `port=3000 go run ${GOPATH}/src/github.com/alexellis/hash-browns/main.go`

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
