### PR TITLE
Trim new-lines from tokens

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -99,7 +99,10 @@ func runClient(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to load file: %s", tokenFile))
 		}
-		token = string(fileData)
+
+		// new-lines will be stripped, this is not configurable and is to
+		// make the code foolproof for beginners
+		token = strings.TrimRight(string(fileData), "\n")
 	} else {
 		tokenVal, err := cmd.Flags().GetString("token")
 		if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/inlets/inlets/pkg/server"
 	"github.com/pkg/errors"
@@ -59,7 +60,10 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to load file: %s", tokenFile))
 		}
-		token = string(fileData)
+
+		// new-lines will be stripped, this is not configurable and is to
+		// make the code foolproof for beginners
+		token = strings.TrimRight(string(fileData), "\n")
 	} else {
 		tokenVal, err := cmd.Flags().GetString("token")
 		if err != nil {


### PR DESCRIPTION
To help out beginners the code that parses a token file is now
forcing a trim of any new-lines.

Fixes: #154

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Testing:

```
kosmos:inlets alex$ echo "pass" > /tmp/token
kosmos:inlets alex$ echo "" >> /tmp/token
kosmos:inlets alex$ cat /tmp/token
pass

kosmos:inlets alex$ ./inlets server --token-from /tmp/token
2020/02/04 08:57:40 Welcome to inlets.dev! Find out more at https://github.com/inlets/inlets
2020/02/04 08:57:40 Starting server - version dev
2020/02/04 08:57:40 Server token: "pass"
2020/02/04 08:57:40 Control Plane Listening on :8000
2020/02/04 08:57:40 Data Plane Listening on :8000
```