### PR TITLE
Fixed connection not established when a token is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Example with a token for client authentication:
 
 ```bash
 export token=$(head -c 16 /dev/urandom | shasum | cut -d" " -f1)
-inlets server --port=8090 --token="$token"
+inlets server --port=8090 --token=$token
 ```
 
 > Note: You can pass the `--token` argument followed by a token value to both the server and client to prevent unauthorized connections to the tunnel.
@@ -246,7 +246,7 @@ export TOKEN="CLIENT-TOKEN-HERE"  # the client token is found on your VPS or on 
 inlets client \
  --remote=$REMOTE \
  --upstream=http://127.0.0.1:3000 \
- --token $TOKEN
+ --token=$TOKEN
 ```
 
 * Replace the `--remote` with the address where your exit-node is running `inlets server`.
@@ -305,8 +305,8 @@ export REMOTE="127.0.0.1:8090"    # for testing inlets on your laptop, replace w
 export TOKEN="CLIENT-TOKEN-HERE"  # the client token is found on your VPS or on start-up of "inlets server"
 inlets client \
  --remote=$REMOTE \
- --token $TOKEN \
- --upstream="store1.example.com=http://127.0.0.1:8001,store2.example.com=http://127.0.0.1:8002"
+ --upstream="store1.example.com=http://127.0.0.1:8001,store2.example.com=http://127.0.0.1:8002" \
+ --token=$TOKEN
 ```
 
 You can now create two DNS entries or `/etc/hosts` file entries for `store1.example.com` and `store2.example.com`, then connect through your browser.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,7 +129,7 @@ func (s *Server) dialerFor(id, host string) remotedialer.Dialer {
 
 func (s *Server) tokenValid(req *http.Request) bool {
 	auth := req.Header.Get("Authorization")
-	return subtle.ConstantTimeCompare([]byte(auth), []byte("Bearer "+s.Token)) == 1
+	return len(s.Token) == 0 || subtle.ConstantTimeCompare([]byte(auth), []byte("Bearer "+s.Token)) == 1
 }
 
 func (s *Server) authorized(req *http.Request) (id string, ok bool, err error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -33,3 +33,15 @@ func Test_tokenValid_Invalid(t *testing.T) {
 		t.Error("expected isTokenValid to be false")
 	}
 }
+
+func Test_emptyToken_Valid(t *testing.T) {
+	token := ""
+	s := &Server{Token: token}
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !s.tokenValid(r) {
+		t.Error("expected isTokenValid to be true")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Simon Su <zsu801@aucklanduni.ac.nz>

## Description
- Closes #158, connection not established when a token is not provided (introduced in #110 - v2.5.1) 
- Minor changes to improve consistency of README.md.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran server and client locally w/ and w/o the --token flag to test connection and added a unit test.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## How are existing users impacted? What migration steps/scripts do we need?
Existing users on v2.5.1 later should not be affected as if a token is provided, as the behaviour will remain the same. However, this should partially unblock users bumping from an older version (w/o token).

## Checklist:
I have:
- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
