### PR TITLE
Support downloading into a folder with a space

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -66,18 +66,18 @@ getPackage() {
         targetFile="$(pwd)/$REPO"
     fi
 
-    if [ -e $targetFile ]; then
-        rm $targetFile
+    if [ -e "$targetFile" ]; then
+        rm "$targetFile"
     fi
 
     url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
-    curl -sSLf $url --output $targetFile
+    curl -sSLf $url --output "$targetFile"
 
     if [ "$?" = "0" ]; then
 
-    chmod +x $targetFile
+    chmod +x "$targetFile"
 
     echo "Download complete."
 
@@ -111,14 +111,14 @@ getPackage() {
 
             fi
 
-            mv $targetFile $BINLOCATION/$REPO
+            mv "$targetFile" $BINLOCATION/$REPO
 
             if [ "$?" = "0" ]; then
                 echo "New version of $REPO installed to $BINLOCATION"
             fi
 
-            if [ -e $targetFile ]; then
-                rm $targetFile
+            if [ -e "$targetFile" ]; then
+                rm "$targetFile"
             fi
 
            ${SUCCESS_CMD}


### PR DESCRIPTION
Signed-off-by: wingkwong <wingkwong.code@gmail.com>

## Description
support for downloading inlets into a folder with space.

## How Has This Been Tested?
Before:
```
test folder with space wingkwong$ ../get.sh 
../get.sh: line 69: [: too many arguments
Downloading package https://github.com/inlets/inlets/releases/download/2.7.0/inlets-darwin as /Users/wingkwong/Documents/GitHub/inlets/test folder with space/inlets
curl: (6) Could not resolve host: folder
curl: (6) Could not resolve host: with
curl: (6) Could not resolve host: space
```

After:
```
test folder with space wingkwong$ ../get.sh 
Downloading package https://github.com/inlets/inlets/releases/download/2.7.0/inlets-darwin as /Users/wingkwong/Documents/GitHub/inlets/test folder with space/inlets
Download complete.

Running with sufficient permissions to attempt to move inlets to /usr/local/bin
New version of inlets installed to /usr/local/bin
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.7.0
Git Commit: ced556795aecc6e2ac514032e78f3096d17bfa25
test folder with space wingkwong$ 
```


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
