### PR TITLE
add option to select address to bind to

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -39,6 +39,7 @@ func init() {
 	serverCmd.Flags().StringP("token-from", "f", "", "read the authentication token from a file")
 	serverCmd.Flags().Bool("disable-transport-wrapping", false, "disable wrapping the transport that removes CORS headers for example")
 	serverCmd.Flags().IntP("control-port", "c", 8080, "control port for tunnel")
+	serverCmd.Flags().StringP("bind-addr", "b", "", "address the server should be bound to")
 
 	inletsCmd.AddCommand(serverCmd)
 }
@@ -110,9 +111,15 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "failed to get the 'disable-transport-wrapping' value.")
 	}
 
+	bindAddr, err := cmd.Flags().GetString("bind-addr")
+	if err != nil {
+		return errors.Wrap(err, "failed to get the 'bind-addr' value.")
+	}
+
 	inletsServer := server.Server{
 		Port:        port,
 		ControlPort: controlPort,
+		BindAddr:    bindAddr,
 		Token:       token,
 
 		DisableWrapTransport: disableWrapTransport,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,8 @@ type Server struct {
 	// ControlPort represents the tunnel to the inlets client
 	ControlPort int
 
+	BindAddr string
+
 	// Token is used to authenticate a client
 	Token string
 
@@ -47,10 +49,10 @@ func (s *Server) Serve() {
 		http.HandleFunc("/", s.proxy)
 		http.HandleFunc("/tunnel", s.tunnel)
 
-		log.Printf("Control Plane Listening on :%d\n", s.ControlPort)
-		log.Printf("Data Plane Listening on :%d\n", s.Port)
+		log.Printf("Control Plane Listening on %s:%d\n", s.BindAddr, s.ControlPort)
+		log.Printf("Data Plane Listening on %s:%d\n", s.BindAddr, s.Port)
 
-		if err := http.ListenAndServe(fmt.Sprintf(":%d", s.Port), nil); err != nil {
+		if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.BindAddr, s.Port), nil); err != nil {
 			log.Fatal(err)
 		}
 	} else {
@@ -67,8 +69,8 @@ func (s *Server) Serve() {
 
 			controlServer.HandleFunc("/tunnel", s.tunnel)
 
-			log.Printf("Control Plane Listening on :%d\n", s.ControlPort)
-			if err := http.ListenAndServe(fmt.Sprintf(":%d", s.ControlPort), controlServer); err != nil {
+			log.Printf("Control Plane Listening on %s:%d\n", s.BindAddr, s.ControlPort)
+			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.BindAddr, s.ControlPort), controlServer); err != nil {
 				log.Fatal(err)
 			}
 
@@ -82,9 +84,9 @@ func (s *Server) Serve() {
 			controlServer.HandleFunc("/", s.proxy)
 
 			http.HandleFunc("/", s.proxy)
-			log.Printf("Data Plane Listening on :%d\n", s.Port)
+			log.Printf("Data Plane Listening on %s:%d\n", s.BindAddr, s.Port)
 
-			if err := http.ListenAndServe(fmt.Sprintf(":%d", s.Port), controlServer); err != nil {
+			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.BindAddr, s.Port), controlServer); err != nil {
 				log.Fatal(err)
 			}
 		}()


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

## Description

Add option to select address to bind to.
Fixes #113 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Go binary, with IP addresses like eg 127.0.0.1

## How are existing users impacted? What migration steps/scripts do we need?

No impact, the new parameter is optional and the default value is the same as before

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
