### PR TITLE
Enable strict filtering feature for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,18 +329,26 @@ Docker images are published as multi-arch for `x86_64`, `arm64` and `armhf`
 
 * `inlets/inlets:2.6.3`
 
-### Multiple services with on exit-node
-
-You can expose an OpenFaaS or OpenFaaS Cloud deployment with `inlets` - just change `--upstream=http://127.0.0.1:3000` to `--upstream=http://127.0.0.1:8080` or `--upstream=http://127.0.0.1:31112`. You can even point at an IP address inside or outside your network for instance: `--upstream=http://192.168.0.101:8080`.
-
-When using the scripts in `hack` to configure inlets with system, the process will restart if the tunnel crashes.
-
 ### Bind a different port for the control-plane
 
 You can bind two separate TCP ports for the user-facing port and the tunnel.
 
 * `--port` - the port for users to connect to and for serving data, i.e. the *Data Plane*
 * `--control-port` - the port for the websocket to connect to i.e. the *Control Plane*
+
+### Strict forwarding policy
+
+By default, the server code can access any host. The client specifies a number of upstream hosts via `--upstream`. If you want these to be the only hosts that the server can connect to, then enable strict forwarding.
+
+* `--strict-forwarding`
+
+This is off by default, however when set to true, only hosts in `--upstream` can be accessed by the server. It could prevent a bad actor from accessing other hosts on your network.
+
+### Multiple services with on exit-node
+
+You can expose an OpenFaaS or OpenFaaS Cloud deployment with `inlets` - just change `--upstream=http://127.0.0.1:3000` to `--upstream=http://127.0.0.1:8080` or `--upstream=http://127.0.0.1:31112`. You can even point at an IP address inside or outside your network for instance: `--upstream=http://192.168.0.101:8080`.
+
+When using the scripts in `hack` to configure inlets with system, the process will restart if the tunnel crashes.
 
 ### Development
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,57 @@
+package client
+
+import "testing"
+
+func Test_AllowsAll_Allows(t *testing.T) {
+	f := makeAllowsAllFilter()
+
+	got := f("tcp", "example.com")
+	want := true
+
+	if got != want {
+		t.Fatalf("connection allowed: want %v, got %v", want, got)
+	}
+}
+
+func Test_StrictFilteringPassesOnMatch(t *testing.T) {
+	u := map[string]string{
+		"tcp": "http://example.com",
+	}
+
+	f := makeFilter(u)
+
+	got := f("tcp", "example.com")
+	want := true
+
+	if got != want {
+		t.Fatalf("connection allowed: want %v, got %v", want, got)
+	}
+}
+
+func Test_StrictFilteringFails(t *testing.T) {
+	u := map[string]string{
+		"tcp": "example.com",
+	}
+
+	f := makeFilter(u)
+
+	got := f("tcp", "test.com")
+	want := false
+
+	if got != want {
+		t.Fatalf("connection allowed: want %v, got %v", want, got)
+	}
+}
+
+func Test_StrictFilteringFailsUDP(t *testing.T) {
+	u := map[string]string{}
+
+	f := makeFilter(u)
+
+	got := f("udp", "example.com")
+	want := false
+
+	if got != want {
+		t.Fatalf("connection allowed: want %v, got %v", want, got)
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -55,7 +55,6 @@ func (r *Router) Lookup(req *http.Request) *Route {
 	if len(targets) == 0 {
 		targets = r.domains[""]
 	}
-
 	if len(targets) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Description

Enable strict filtering of upstream hosts in the client

There was an issue reported by a user about the allow code
which meant any host could be set by the server in a dial
request without any validation. This behaviour was as designed,
however some users may want a strict list of upstream hosts
to be the only ones that can be contacted.

Fixes: #165

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by hacking the server code to change the host being
dialed to one not specified by the client. This resulted in
a disconnect and denial of access.

## How are existing users impacted? What migration steps/scripts do we need?

Optional feature: off by default. It would make sense for most people to use this feature.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests