### PR TITLE
Add new latest Docker Tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ after_success:
   - make docker-login
   - make push
   - make manifest
+  - make manifest-latest
   - make docker-login-ghcr
   - make tag-ghcr
   - make push-ghcr

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ after_success:
   - make docker-login
   - make push
   - make manifest
-  - make manifest-latest
   - make docker-login-ghcr
   - make tag-ghcr
   - make push-ghcr
   - make manifest-ghcr
+  - |
+    if [[ -n "$TRAVIS_TAG" ]]; then
+      make manifest-latest
+    fi
 
 before_deploy:
   - ./ci/hashgen.sh

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,13 @@ manifest:
 	docker manifest annotate inlets/inlets:$(Version) inlets/inlets:$(Version)-armhf --os linux --arch arm --variant v6
 	docker manifest push inlets/inlets:$(Version)
 
+.PHONY: manifest-latest
+manifest-latest:
+	docker manifest create --amend inlets/inlets:latest inlets/inlets:$(Version)-amd64 inlets/inlets:$(Version)-arm64 inlets/inlets:$(Version)-armhf
+	docker manifest annotate inlets/inlets:latest inlets/inlets:$(Version)-arm64 --os linux --arch arm64
+	docker manifest annotate inlets/inlets:latest inlets/inlets:$(Version)-armhf --os linux --arch arm --variant v6
+	docker manifest push inlets/inlets:latest
+
 .PHONY: manifest-ghcr
 manifest-ghcr:
 	docker manifest create --amend ghcr.io/inlets/inlets:$(Version) ghcr.io/inlets/inlets:$(Version)-amd64 ghcr.io/inlets/inlets:$(Version)-arm64 ghcr.io/inlets/inlets:$(Version)-armhf


### PR DESCRIPTION
## Description
- Add new `latest` Docker Tag for multiple use cases:
  - Always get the latest version when creating the docker container.
  - Allow the users to use `docker pull inlets/inlets` without receiving the error: `manifest for inlets/inlets:latest not found`.
  - Allow the use of services like `containrrr/watchtower` to keep the containers always up to date.

- Only update the `latest` tag if it's a git Tag. 

## How Has This Been Tested?
Manually ran the `make manifest-latest` command.
Environment: Ubuntu 18.04.4 LTS; Docker version 19.03.11, build dd360c7
The only error that I got was no permission to push.


## How are existing users impacted? What migration steps/scripts do we need?
None.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
