### PR TITLE
added setup info for caddy v2 in docs

### DIFF
--- a/docs/vps.md
+++ b/docs/vps.md
@@ -40,6 +40,7 @@ cat /etc/default/inlets
 
 * Enter this text into a Caddyfile replacing `exit.domain.com` with your subdomain.
 
+### Caddy v1
 ```Caddyfile
 exit.domain.com
 
@@ -50,6 +51,27 @@ proxy / 127.0.0.1:8000 {
 proxy /tunnel 127.0.0.1:8000 {
   transparent
   websocket
+}
+```
+
+### Caddy v2
+```Caddyfile
+exit.domain.com
+
+reverse_proxy / 127.0.0.1:8000 {
+  header_up Host {http.request.host}
+  header_up X-Real-IP {http.request.remote}
+  header_up X-Forwarded-For {http.request.remote}
+  header_up X-Forwarded-Port {http.request.port}
+  header_up X-Forwarded-Proto {http.request.scheme}
+}
+
+reverse_proxy /tunnel 127.0.0.1:8000 {
+  header_up Host {http.request.host}
+  header_up X-Real-IP {http.request.remote}
+  header_up X-Forwarded-For {http.request.remote}
+  header_up X-Forwarded-Port {http.request.port}
+  header_up X-Forwarded-Proto {http.request.scheme}
 }
 ```
 


### PR DESCRIPTION
## Description
The instructions in the docs are for v1, and does not apply to v2 as directives such as `transparent` and `websockets` so no longer exists. Instead headers are used to use these features. 

Also, `proxy` has been renamed to `reverse_proxy` in v2. 

This pull request simply updates the docs with the proper setup for Caddy v2.

## How Has This Been Tested?
This was tested in a Google cloud f1-micro with Caddy versions `2.2.0-rc3` and `2.1.0`. The only files modified during testing was the `Caddyfile` which included the as documented headers setup and ran with `caddy run`. Inlets was ran as already documented. 

Testing was also conducted against both an express server and python built in http server and success from both.  


## How are existing users impacted? What migration steps/scripts do we need?
0

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
