### PR TITLE
server.go: data-addr parameter has no effect

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -120,9 +120,9 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "failed to get the 'disable-transport-wrapping' value.")
 	}
 
-	dataAddr, err := cmd.Flags().GetString("control-addr")
+	dataAddr, err := cmd.Flags().GetString("data-addr")
 	if err != nil {
-		return errors.Wrap(err, "failed to get the 'control-addr' value.")
+		return errors.Wrap(err, "failed to get the 'data-addr' value.")
 	}
 
 	controlAddr, err := cmd.Flags().GetString("control-addr")


### PR DESCRIPTION
## Description

it's impossible to change `data-addr` parameter, so PR should fix this

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

unable to expose insecure endpoint

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
